### PR TITLE
Fixed crash inside -recognizedText in cases where tesseract returns NULL

### DIFF
--- a/TesseractOCR/Tesseract.mm
+++ b/TesseractOCR/Tesseract.mm
@@ -132,6 +132,10 @@ namespace tesseract {
 
 - (NSString *)recognizedText {
 	char* utf8Text = _tesseract->GetUTF8Text();
+	if (!utf8Text) {
+		NSLog(@"No recognized text. Check that -[Tesseract setImage:] is passed an image bigger than 0x0.");
+		return nil;
+	}
 	return [NSString stringWithUTF8String:utf8Text];
 }
 


### PR DESCRIPTION
When running the app with an invalid "image_sample.jpg" the app crashes like this:

```
2013-11-27 09:10:23.017 Template Framework Project[771:60b] DATAPATH /var/mobile/Applications/D23DF049-A133-4B12-B0EE-096076CCE77A/Documents/tessdata
2013-11-27 09:10:23.032 Template Framework Project[771:60b] trovato a /var/mobile/Applications/D23DF049-A133-4B12-B0EE-096076CCE77A/Template Framework Project.app/eng.traineddata
2013-11-27 09:10:23.037 Template Framework Project[771:60b] lo copio in /var/mobile/Applications/D23DF049-A133-4B12-B0EE-096076CCE77A/Documents/tessdata/eng.traineddata
Please call SetImage before attempting recognition.Please call SetImage before attempting recognition.2013-11-27 09:10:25.610 Template Framework Project[771:60b] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** +[NSString stringWithUTF8String:]: NULL cString'
*** First throw call stack:
(0x2e663f4b 0x389f36af 0x2e663e8d 0x2ef7b4ef 0x13fbb 0x12f97 0x30ddb37b 0x30ddb139 0x30de1e05 0x30ddf4db 0x30e4a08d 0x30e46e59 0x30e41353 0x30ddc41f 0x30ddb721 0x30e40b3d 0x3327770d 0x332772f7 0x2e62e9df 0x2e62e97b 0x2e62d14f 0x2e597c27 0x2e597a0b 0x30e3fdd9 0x30e3b049 0x12bfd 0x38efbab7)
libc++abi.dylib: terminating with uncaught exception of type NSException
```
