### PR TITLE
Migrate sections of README.md to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@ Getting Started
 =================
 See the [Installation](https://github.com/gali8/Tesseract-OCR-iOS/wiki/Installation) page in the wiki. Once you're setup see some [usage examples](https://github.com/gali8/Tesseract-OCR-iOS/wiki/Using-Tesseract-OCR-iOS).
 
-Building From Source
-=================
-You can generate "TesseractOCR.framework" yourself by building the
-**TesseractOCRAggregate** target in "Tesseract OCR iOS.xcodeproj".
-
 Known Limitations
 =================
 


### PR DESCRIPTION
Older release notes have been moved to the wiki, while newer releases will be mainted through the GitHub releases feature.
