### PR TITLE
Fix image equality for tests

### DIFF
--- a/Tesseract-OCR-iOS.xcworkspace/xcshareddata/xcschemes/TestsProject.xcscheme
+++ b/Tesseract-OCR-iOS.xcworkspace/xcshareddata/xcschemes/TestsProject.xcscheme
@@ -65,11 +65,6 @@
                BlueprintName = "TestsProjectTests"
                ReferencedContainer = "container:TestsProject/TestsProject.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "RecognitionTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/TestsProject/TestsProjectTests/UIImage+G8Equal.m
+++ b/TestsProject/TestsProjectTests/UIImage+G8Equal.m
@@ -18,7 +18,7 @@ static CGFloat const kG8MinimalSimilarity = 0.99;
         return YES;
     }
 
-    CGFloat similarity = [self g8_similarityWithImage:image];
+    CGFloat similarity = [[self g8_normalizedImage] g8_similarityWithImage:[image g8_normalizedImage]];
     return similarity > kG8MinimalSimilarity;
 }
 
@@ -35,7 +35,7 @@ static CGFloat const kG8MinimalSimilarity = 0.99;
 
     CGContextRef context = CGBitmapContextCreate(pixels, width, height, 8, width * sizeof(uint32_t), colorSpace,
                                                  kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedLast);
-    CGContextDrawImage(context, CGRectMake(0, 0, width, height), [[self g8_normalizedImage] CGImage]);
+    CGContextDrawImage(context, CGRectMake(0, 0, width, height), self.CGImage);
 
     CGContextRelease(context);
     CGColorSpaceRelease(colorSpace);

--- a/TestsProject/TestsProjectTests/UIImage+G8Equal.m
+++ b/TestsProject/TestsProjectTests/UIImage+G8Equal.m
@@ -8,8 +8,6 @@
 
 #import "UIImage+G8Equal.h"
 
-#import <CommonCrypto/CommonDigest.h>
-
 static CGFloat const kG8MinimalSimilarity = 0.99;
 
 @implementation UIImage (G8Equal)


### PR DESCRIPTION
I've updated method of checking images equality in tests. Now it's allows 1% differences between images. It resolves problems with failing tests in iOS 7(images are equal, but there was something different in PNG-representation).