### PR TITLE
 Automatically call + (void)clearCache on memory warning #119 

### DIFF
--- a/TesseractOCR/G8Tesseract.h
+++ b/TesseractOCR/G8Tesseract.h
@@ -28,8 +28,9 @@
  *  Clear any library-level memory caches.
  *  There are a variety of expensive-to-load constant data structures (mostly
  *  language dictionaries) that are cached globally. This function allows the
- *  clearing of these caches. It's safe to call this method, while a recognition is in progress.
- *  It's also called automatically on UIApplicationDidReceiveMemoryWarningNotification
+ *  clearing of these caches. It's safe to call this method, while a 
+ *  recognition is in progress. It's also called automatically on 
+ *  UIApplicationDidReceiveMemoryWarningNotification
  */
 + (void)clearCache;
 

--- a/TesseractOCR/G8Tesseract.h
+++ b/TesseractOCR/G8Tesseract.h
@@ -28,7 +28,8 @@
  *  Clear any library-level memory caches.
  *  There are a variety of expensive-to-load constant data structures (mostly
  *  language dictionaries) that are cached globally. This function allows the
- *  clearing of these caches.
+ *  clearing of these caches. It's safe to call this method, while a recognition is in progress.
+ *  It's also called automatically on UIApplicationDidReceiveMemoryWarningNotification
  */
 + (void)clearCache;
 

--- a/TesseractOCR/G8Tesseract.mm
+++ b/TesseractOCR/G8Tesseract.mm
@@ -37,7 +37,6 @@ namespace tesseract {
 
 @property (readwrite, assign) CGSize imageSize;
 
-@property (nonatomic, readwrite, copy) NSString *absoluteDataPath;
 @property (nonatomic, assign, getter=isRecognized) BOOL recognized;
 @property (nonatomic, assign, getter=isLayoutAnalysed) BOOL layoutAnalysed;
 
@@ -107,7 +106,7 @@ namespace tesseract {
             NSAssert([configFileNames isKindOfClass:[NSArray class]], @"Error! configFileNames should be of type NSArray");
         }
 
-        self.absoluteDataPath = [cachesRelatedPath copy];
+        _absoluteDataPath = [cachesRelatedPath copy];
         _language = [language copy];
         _configDictionary = configDictionary;
         _configFileNames = configFileNames;
@@ -126,7 +125,7 @@ namespace tesseract {
             NSArray *cachesPaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
             NSString *cachesPath = cachesPaths.firstObject;
 
-            self.absoluteDataPath = [cachesPath stringByAppendingPathComponent:self.absoluteDataPath].copy;
+            _absoluteDataPath = [cachesPath stringByAppendingPathComponent:_absoluteDataPath].copy;
 
             BOOL success = [self moveTessdataToCachesDirectoryIfNecessary];
             if (success == NO) {
@@ -135,10 +134,10 @@ namespace tesseract {
         }
         else {
             // config Tesseract to search trainedData in tessdata folder of the application bundle];
-            self.absoluteDataPath = [NSString stringWithFormat:@"%@", [NSString stringWithString:[NSBundle mainBundle].bundlePath]].copy;
+            _absoluteDataPath = [NSString stringWithFormat:@"%@", [NSString stringWithString:[NSBundle mainBundle].bundlePath]].copy;
         }
         
-        setenv("TESSDATA_PREFIX", [self.absoluteDataPath stringByAppendingString:@"/"].UTF8String, 1);
+        setenv("TESSDATA_PREFIX", [_absoluteDataPath stringByAppendingString:@"/"].UTF8String, 1);
 
         _tesseract = new tesseract::TessBaseAPI();
 

--- a/TesseractOCR/G8Tesseract.mm
+++ b/TesseractOCR/G8Tesseract.mm
@@ -51,6 +51,22 @@ namespace tesseract {
 
 @synthesize absoluteDataPath=_absoluteDataPath;
 
++ (void)initialize {
+    
+    [super initialize];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(didReceiveMemoryWarningNotification:)
+                                                 name:UIApplicationDidReceiveMemoryWarningNotification
+                                               object:nil];
+}
+
++ (void)didReceiveMemoryWarningNotification:(NSNotification*)notification {
+    
+    [self clearCache];
+    // some more cleaning here if necessary
+}
+
 + (NSString *)version
 {
     const char *version = tesseract::TessBaseAPI::Version();

--- a/TesseractOCR/G8Tesseract.mm
+++ b/TesseractOCR/G8Tesseract.mm
@@ -37,6 +37,7 @@ namespace tesseract {
 
 @property (readwrite, assign) CGSize imageSize;
 
+@property (nonatomic, readwrite, copy) NSString *absoluteDataPath;
 @property (nonatomic, assign, getter=isRecognized) BOOL recognized;
 @property (nonatomic, assign, getter=isLayoutAnalysed) BOOL layoutAnalysed;
 
@@ -48,8 +49,6 @@ namespace tesseract {
 @end
 
 @implementation G8Tesseract
-
-@synthesize absoluteDataPath=_absoluteDataPath;
 
 + (void)initialize {
     
@@ -108,7 +107,7 @@ namespace tesseract {
             NSAssert([configFileNames isKindOfClass:[NSArray class]], @"Error! configFileNames should be of type NSArray");
         }
 
-        _absoluteDataPath = [cachesRelatedPath copy];
+        self.absoluteDataPath = [cachesRelatedPath copy];
         _language = [language copy];
         _configDictionary = configDictionary;
         _configFileNames = configFileNames;
@@ -122,12 +121,12 @@ namespace tesseract {
         _monitor->cancel = (CANCEL_FUNC)[self methodForSelector:@selector(tesseractCancelCallbackFunction:)];
         _monitor->cancel_this = (__bridge void*)self;
 
-        if (_absoluteDataPath != nil) {
+        if (self.absoluteDataPath != nil) {
             // config Tesseract to search trainedData in tessdata folder of the Caches folder
             NSArray *cachesPaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
             NSString *cachesPath = cachesPaths.firstObject;
 
-            _absoluteDataPath = [cachesPath stringByAppendingPathComponent:_absoluteDataPath].copy;
+            self.absoluteDataPath = [cachesPath stringByAppendingPathComponent:self.absoluteDataPath].copy;
 
             BOOL success = [self moveTessdataToCachesDirectoryIfNecessary];
             if (success == NO) {
@@ -136,10 +135,10 @@ namespace tesseract {
         }
         else {
             // config Tesseract to search trainedData in tessdata folder of the application bundle];
-            _absoluteDataPath = [NSString stringWithFormat:@"%@", [NSString stringWithString:[NSBundle mainBundle].bundlePath]].copy;
+            self.absoluteDataPath = [NSString stringWithFormat:@"%@", [NSString stringWithString:[NSBundle mainBundle].bundlePath]].copy;
         }
         
-        setenv("TESSDATA_PREFIX", [_absoluteDataPath stringByAppendingString:@"/"].UTF8String, 1);
+        setenv("TESSDATA_PREFIX", [self.absoluteDataPath stringByAppendingString:@"/"].UTF8String, 1);
 
         _tesseract = new tesseract::TessBaseAPI();
 

--- a/TesseractOCR/include/tesseract/genericvector.h
+++ b/TesseractOCR/include/tesseract/genericvector.h
@@ -335,7 +335,7 @@ inline bool LoadDataFromFile(const STRING& filename,
   size_t size = ftell(fp);
   fseek(fp, 0, SEEK_SET);
   // Pad with a 0, just in case we treat the result as a string.
-  data->init_to_size(size + 1, 0);
+  data->init_to_size((int)size + 1, 0);
   bool result = fread(&(*data)[0], 1, size, fp) == size;
   fclose(fp);
   return result;

--- a/TesseractOCR/include/tesseract/helpers.h
+++ b/TesseractOCR/include/tesseract/helpers.h
@@ -30,7 +30,7 @@
 
 // Remove newline (if any) at the end of the string.
 inline void chomp_string(char *str) {
-  int last_index = strlen(str) - 1;
+  int last_index = (int)strlen(str) - 1;
   while (last_index >= 0 &&
          (str[last_index] == '\n' || str[last_index] == '\r')) {
     str[last_index--] = '\0';

--- a/TestsProject/TestsProjectTests/InitializationTests.m
+++ b/TestsProject/TestsProjectTests/InitializationTests.m
@@ -55,8 +55,8 @@ describe(@"Tesseract initialization", ^{
             [[[G8Tesseract version] should] equal:@"3.03"];
         });
         
-        it(@"Should clear cache", ^{
-            // while recognition is in progress
+        it(@"Should not raise on cache clearing", ^{
+            //
             for (int i = 0; i <= 10; i++) {
                 G8RecognitionOperation *operation = [[G8RecognitionOperation alloc] init];
                 operation.tesseract.image = [UIImage imageNamed:@"well_scaned_page"];
@@ -69,7 +69,9 @@ describe(@"Tesseract initialization", ^{
             [[theBlock(^{
                 [G8Tesseract clearCache];
             }) shouldNot] raise];
-            
+        });
+        
+        it(@"Should clear cache on memory warning", ^{
             // should be called on a memory warning notification
             [[G8Tesseract should] receive:@selector(didReceiveMemoryWarningNotification:)];
             [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidReceiveMemoryWarningNotification object:nil];

--- a/TestsProject/TestsProjectTests/InitializationTests.m
+++ b/TestsProject/TestsProjectTests/InitializationTests.m
@@ -13,6 +13,7 @@
 #import "Defaults.h"
 
 @interface G8Tesseract (Tests)
++ (void)didReceiveMemoryWarningNotification:(NSNotification*)notification;
 - (BOOL)configEngine;
 - (BOOL)resetEngine;
 @end
@@ -52,6 +53,26 @@ describe(@"Tesseract initialization", ^{
         
         it(@"Should check version", ^{
             [[[G8Tesseract version] should] equal:@"3.03"];
+        });
+        
+        it(@"Should clear cache", ^{
+            // while recognition is in progress
+            for (int i = 0; i <= 10; i++) {
+                G8RecognitionOperation *operation = [[G8RecognitionOperation alloc] init];
+                operation.tesseract.image = [UIImage imageNamed:@"well_scaned_page"];
+                operation.tesseract.language = kG8Languages;
+
+                NSOperationQueue *queue = [[NSOperationQueue alloc] init];
+                [queue addOperation:operation];
+            }
+            
+            [[theBlock(^{
+                [G8Tesseract clearCache];
+            }) shouldNot] raise];
+            
+            // should be called on a memory warning notification
+            [[G8Tesseract should] receive:@selector(didReceiveMemoryWarningNotification:)];
+            [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidReceiveMemoryWarningNotification object:nil];
         });
     });
     

--- a/TestsProject/TestsProjectTests/InitializationTests.m
+++ b/TestsProject/TestsProjectTests/InitializationTests.m
@@ -195,7 +195,7 @@ describe(@"Tesseract initialization", ^{
     
     context(@"moveTessdataToCachesDirectoryIfNecessary", ^{
         
-        void (^checkInitializationWithFailedSelectorReturnValueAndCount)(SEL selector, id returnValue, int count) = ^(SEL selector, id returnValue, int count){
+        void (^checkInitializationWithFailedSelectorReturnValueAndCount)(SEL selector, id returnValue, NSUInteger count) = ^(SEL selector, id returnValue, NSUInteger count){
             G8Tesseract *wrongTesseract = [G8Tesseract alloc];
             [[wrongTesseract shouldNot] beNil];
             [[[NSFileManager defaultManager] should] receive:selector andReturn:returnValue withCount:count];


### PR DESCRIPTION
1. clearCache is now called right after memory warning notification has been send. A note about this is added to the .h
2. Tests are added.
2.1 checking that clearCache calls are safe, while there is a recognition is in process. A note about this is also added to .h
2.2 checking that clearCache is automatically called on UIApplicationDidReceiveMemoryWarningNotification