### PR TITLE
Removed default initializers. Fixes #145.

### DIFF
--- a/Template Framework Project/Template Framework Project/G8ViewController.m
+++ b/Template Framework Project/Template Framework Project/G8ViewController.m
@@ -42,14 +42,12 @@
     self.imageToRecognize.image = bwImage;
 
     // Create a new `G8RecognitionOperation` to perform the OCR asynchronously
-    G8RecognitionOperation *operation = [[G8RecognitionOperation alloc] init];
-    
     // It is assumed that there is a .traineddata file for the language pack
     // you want Tesseract to use in the "tessdata" folder in the root of the
     // project AND that the "tessdata" folder is a referenced folder and NOT
     // a symbolic group in your project
-    operation.tesseract.language = @"eng";
-    
+    G8RecognitionOperation *operation = [[G8RecognitionOperation alloc] initWithLanguage:@"eng"];
+
     // Use the original Tesseract engine mode in performing the recognition
     // (see G8Constants.h) for other engine mode options
     operation.tesseract.engineMode = G8OCREngineModeTesseractOnly;

--- a/TesseractOCR/G8RecognitionOperation.h
+++ b/TesseractOCR/G8RecognitionOperation.h
@@ -61,4 +61,18 @@ typedef void(^G8RecognitionOperationCallback)(G8Tesseract *tesseract);
 /// @deprecated	Use property recognitionCompleteBlock instead
 @property (copy) void (^completionBlock)(void) DEPRECATED_ATTRIBUTE;
 
+/// The default initializer should not be used since the language Tesseract
+/// uses needs to be explicit.
+- (instancetype)init __attribute__((unavailable("Use initWithLanguage:language instead")));
+
+/**
+ *  Initialize a G8RecognitionOperation with the provided language.
+ *
+ *  @param language The language to use in recognition.
+ *
+ *  @return The initialized G8RecognitionOperation object, or `nil` if there 
+ *          was an error.
+ */
+- (id)initWithLanguage:(NSString*)language;
+
 @end

--- a/TesseractOCR/G8RecognitionOperation.m
+++ b/TesseractOCR/G8RecognitionOperation.m
@@ -20,11 +20,11 @@
 
 @implementation G8RecognitionOperation
 
-- (id)init
+- (id) initWithLanguage:(NSString *)language
 {
     self = [super init];
     if (self != nil) {
-        _tesseract = [[G8Tesseract alloc] init];
+        _tesseract = [[G8Tesseract alloc] initWithLanguage:language];
         _tesseract.delegate = self;
 
         __weak __typeof(self) weakSelf = self;

--- a/TesseractOCR/G8Tesseract.h
+++ b/TesseractOCR/G8Tesseract.h
@@ -243,6 +243,10 @@ extern NSInteger const kG8MaxCredibleResolution;
  */
 @property (nonatomic, weak) id<G8TesseractDelegate> delegate;
 
+/// The default initializer should not be used since the language Tesseract
+/// uses needs to be explicit.
+- (instancetype)init __attribute__((unavailable("Use initWithLanguage:language instead")));
+
 /**
  *  Initialize Tesseract with the provided language.
  *

--- a/TesseractOCR/G8Tesseract.mm
+++ b/TesseractOCR/G8Tesseract.mm
@@ -80,11 +80,6 @@ namespace tesseract {
     tesseract::TessBaseAPI::ClearPersistentCache();
 }
 
-- (id)init
-{
-    return [self initWithLanguage:nil];
-}
-
 - (id)initWithLanguage:(NSString*)language
 {
     return [self initWithLanguage:language configDictionary:nil configFileNames:nil cachesRelatedDataPath:nil engineMode:G8OCREngineModeTesseractOnly];

--- a/TestsProject/TestsProjectTests/G8RecognitionTestsHelper.m
+++ b/TestsProject/TestsProjectTests/G8RecognitionTestsHelper.m
@@ -51,7 +51,7 @@ static NSString *const kG8Languages = @"eng";
 - (void)setupTesseract
 {
     if (self.tesseract == nil) {
-        self.tesseract = [[G8Tesseract alloc] init];
+        self.tesseract = [[G8Tesseract alloc] initWithLanguage:@"eng"];
     }
     
     self.tesseract.delegate = self;
@@ -79,7 +79,7 @@ static NSString *const kG8Languages = @"eng";
 
 - (void)recognizeImage
 {
-    self.tesseract = [[G8Tesseract alloc] init];
+    self.tesseract = [[G8Tesseract alloc] initWithLanguage:kG8Languages];
     [self setupTesseract];
     [self setupImage];
 
@@ -88,7 +88,7 @@ static NSString *const kG8Languages = @"eng";
 
 - (void)recognizeImageUsingOperation
 {
-    G8RecognitionOperation *operation = [[G8RecognitionOperation alloc] init];
+    G8RecognitionOperation *operation = [[G8RecognitionOperation alloc] initWithLanguage:kG8Languages];
     self.tesseract = operation.tesseract;
     [self setupTesseract];
 
@@ -119,7 +119,7 @@ static NSString *const kG8Languages = @"eng";
 
 - (UIImage *)thresholdedImageForImage:(UIImage *)sourceImage
 {
-    self.tesseract = [[G8Tesseract alloc] init];
+    self.tesseract = [[G8Tesseract alloc] initWithLanguage:kG8Languages];
     [self setupTesseract];
 
     self.tesseract.image = [sourceImage g8_blackAndWhite];

--- a/TestsProject/TestsProjectTests/G8RecognitionTestsHelper.m
+++ b/TestsProject/TestsProjectTests/G8RecognitionTestsHelper.m
@@ -51,7 +51,7 @@ static NSString *const kG8Languages = @"eng";
 - (void)setupTesseract
 {
     if (self.tesseract == nil) {
-        self.tesseract = [[G8Tesseract alloc] initWithLanguage:@"eng"];
+        self.tesseract = [[G8Tesseract alloc] initWithLanguage:kG8Languages];
     }
     
     self.tesseract.delegate = self;

--- a/TestsProject/TestsProjectTests/InitializationTests.m
+++ b/TestsProject/TestsProjectTests/InitializationTests.m
@@ -66,7 +66,7 @@ describe(@"Tesseract initialization", ^{
         it(@"Should not raise on cache clearing", ^{
             //
             for (int i = 0; i <= 10; i++) {
-                G8RecognitionOperation *operation = [[G8RecognitionOperation alloc] init];
+                G8RecognitionOperation *operation = [[G8RecognitionOperation alloc] initWithLanguage:kG8Languages];
                 operation.tesseract.image = [UIImage imageNamed:@"well_scaned_page"];
                 operation.tesseract.language = kG8Languages;
 
@@ -99,11 +99,11 @@ describe(@"Tesseract initialization", ^{
             [[tesseract shouldNot] beNil];
             NSAssert([tesseract respondsToSelector:@selector(configEngine)] == YES, @"Error! G8Tesseract instance does not contain configEngine selector");
             [[tesseract should] receive:@selector(configEngine) andReturn:theValue(NO)];
-            tesseract = [tesseract init];
+            tesseract = [tesseract initWithLanguage:kG8Languages];
             
             [[tesseract should] beNil];
             
-            tesseract = [[G8Tesseract alloc] init];
+            tesseract = [[G8Tesseract alloc] initWithLanguage:kG8Languages];
             NSAssert([tesseract respondsToSelector:@selector(resetEngine)] == YES, @"Error! G8Tesseract instance does not contain resetEngine selector");
             [[tesseract should] receive:@selector(configEngine) andReturn:theValue(NO)];
             [[theValue([tesseract resetEngine]) should] beNo];

--- a/TestsProject/TestsProjectTests/RecognitionTests.m
+++ b/TestsProject/TestsProjectTests/RecognitionTests.m
@@ -13,6 +13,7 @@
 
 #import "G8RecognitionTestsHelper.h"
 #import "UIImage+G8Equal.h"
+#import "Defaults.h"
 
 SPEC_BEGIN(RecognitionTests)
 
@@ -288,7 +289,7 @@ describe(@"hOCR", ^{
     });
     
     it(@"Should return nil without prerecognition", ^{
-        G8Tesseract *tesseract = [[G8Tesseract alloc] init];
+        G8Tesseract *tesseract = [[G8Tesseract alloc] initWithLanguage:kG8Languages];
         
         NSString *hOCR = [tesseract recognizedHOCRForPageNumber:0];
         [[hOCR should] beNil];


### PR DESCRIPTION
I made our default initializers for Tesseract unavailable because
they passed `nil` as the language to Tesseract, which it turns
out makes Tesseract default to "eng" for language. That's not
good behavior, because the user may not have eng.traineddata in
their tessdata folder, and thus Tesseract will crash.