### PR TITLE
Initialize can be run many times 

### DIFF
--- a/TesseractOCR/G8Tesseract.mm
+++ b/TesseractOCR/G8Tesseract.mm
@@ -58,10 +58,12 @@ namespace tesseract {
     
     [super initialize];
     
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(didReceiveMemoryWarningNotification:)
-                                                 name:UIApplicationDidReceiveMemoryWarningNotification
-                                               object:nil];
+    if (self == [G8Tesseract self]) {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didReceiveMemoryWarningNotification:)
+                                                     name:UIApplicationDidReceiveMemoryWarningNotification
+                                                   object:nil];
+    }
 }
 
 + (void)didReceiveMemoryWarningNotification:(NSNotification*)notification {


### PR DESCRIPTION
as shown here: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSObject_Class/index.html#//apple_ref/occ/clm/NSObject/initialize.

To avoid this a condition has been added.