### PR TITLE
Added a fully configurable version of G8RecognitionOperation:initWithLanguage routine

### DIFF
--- a/TesseractOCR/G8RecognitionOperation.h
+++ b/TesseractOCR/G8RecognitionOperation.h
@@ -72,4 +72,11 @@ typedef void(^G8RecognitionOperationCallback)(G8Tesseract *tesseract);
  */
 - (id)initWithLanguage:(NSString*)language;
 
+- (id)initWithLanguage:(NSString *)language
+      configDictionary:(NSDictionary *)configDictionary
+       configFileNames:(NSArray *)configFileNames
+      absoluteDataPath:(NSString *)absoluteDataPath
+            engineMode:(G8OCREngineMode)engineMode
+copyFilesFromResources:(BOOL)copyFilesFromResources;
+
 @end

--- a/TesseractOCR/G8RecognitionOperation.m
+++ b/TesseractOCR/G8RecognitionOperation.m
@@ -90,4 +90,12 @@ copyFilesFromResources:(BOOL)copyFilesFromResources
     return canceled;
 }
 
+- (UIImage *)preprocessedImageForTesseract:(G8Tesseract *)tesseract sourceImage:(UIImage *)sourceImage
+{
+    if ([self.delegate respondsToSelector:@selector(preprocessedImageForTesseract:sourceImage:)]) {
+        return [self.delegate preprocessedImageForTesseract:tesseract sourceImage:sourceImage];
+    }
+    return nil;
+}
+
 @end

--- a/TesseractOCR/G8RecognitionOperation.m
+++ b/TesseractOCR/G8RecognitionOperation.m
@@ -22,9 +22,24 @@
 
 - (id) initWithLanguage:(NSString *)language
 {
+    return [self initWithLanguage:language configDictionary:nil configFileNames:nil absoluteDataPath:nil engineMode:G8OCREngineModeTesseractOnly copyFilesFromResources: FALSE];
+}
+
+- (id)initWithLanguage:(NSString *)language
+      configDictionary:(NSDictionary *)configDictionary
+       configFileNames:(NSArray *)configFileNames
+      absoluteDataPath:(NSString *)absoluteDataPath
+            engineMode:(G8OCREngineMode)engineMode
+copyFilesFromResources:(BOOL)copyFilesFromResources
+{
     self = [super init];
     if (self != nil) {
-        _tesseract = [[G8Tesseract alloc] initWithLanguage:language];
+        _tesseract = [[G8Tesseract alloc] initWithLanguage:language
+                                          configDictionary:configDictionary
+                                           configFileNames:configFileNames
+                                          absoluteDataPath:absoluteDataPath
+                                                engineMode:engineMode
+                                    copyFilesFromResources:copyFilesFromResources];
         _tesseract.delegate = self;
 
         __weak __typeof(self) weakSelf = self;
@@ -73,14 +88,6 @@
         canceled = [self.delegate shouldCancelImageRecognitionForTesseract:tesseract];
     }
     return canceled;
-}
-
-- (UIImage *)preprocessedImageForTesseract:(G8Tesseract *)tesseract sourceImage:(UIImage *)sourceImage
-{
-    if ([self.delegate respondsToSelector:@selector(preprocessedImageForTesseract:sourceImage:)]) {
-        return [self.delegate preprocessedImageForTesseract:tesseract sourceImage:sourceImage];
-    }
-    return nil;
 }
 
 @end


### PR DESCRIPTION
Because of the call to the original version of `initWithLanguage` is covered with unit tests and the new one is just called from it for now, it seems to me that no changes in unit tests required.
