### PR TITLE
Fixes issue when registered observer is deallocated

### DIFF
--- a/TesseractOCR/G8Tesseract.mm
+++ b/TesseractOCR/G8Tesseract.mm
@@ -164,6 +164,7 @@ namespace tesseract {
         _monitor = nullptr;
     }
     [self freeTesseract];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)freeTesseract {


### PR DESCRIPTION

This is problematic as if the object is not unregistered the notification center can still send notification even after the object has been deallocated. In that case we would get a crash.