### PR TITLE
Updated Makefile to build properly

### DIFF
--- a/TesseractOCR/Makefile
+++ b/TesseractOCR/Makefile
@@ -1,5 +1,5 @@
 LEPTON_NAME = leptonica-1.72
-PNG_NAME    = libpng-1.6.20
+PNG_NAME    = libpng-1.6.34
 JPEG_NAME   = jpeg-9a
 TIFF_NAME   = tiff-4.0.4
 


### PR DESCRIPTION
Currently the wrong path exists for `libpng` in the Makefile if you'd like to build the frameworks yourself. I modified it to point to the link ftp url.