### PR TITLE
Fixed crash when accessing characterChoices on empty image

### DIFF
--- a/TesseractOCR/G8Tesseract.mm
+++ b/TesseractOCR/G8Tesseract.mm
@@ -811,7 +811,7 @@ namespace tesseract {
 		block.isNumeric = iterator->WordIsNumeric();
 		block.isBold = isBold;
 		block.isItalic = isItalic;
-	} else if (iteratorLevel == G8PageIteratorLevelSymbol) {
+	} else if (iteratorLevel == G8PageIteratorLevelSymbol && block.text != nil) {
 		// get character choices
 		NSMutableArray *choices = [NSMutableArray array];
 
@@ -847,24 +847,26 @@ namespace tesseract {
     if (resultIterator != NULL) {
         do {
             G8RecognizedBlock *block = [self blockFromIterator:resultIterator iteratorLevel:G8PageIteratorLevelSymbol];
-            NSMutableArray *choices = [NSMutableArray array];
+            if(block.text != nil) {
+                NSMutableArray *choices = [NSMutableArray array];
 
-            tesseract::ChoiceIterator choiceIterator(*resultIterator);
-            do {
-                const char *choiceWord = choiceIterator.GetUTF8Text();
-                if (choiceWord != NULL) {
-                    NSString *text = [NSString stringWithUTF8String:choiceWord];
-                    CGFloat confidence = choiceIterator.Confidence();
+                tesseract::ChoiceIterator choiceIterator(*resultIterator);
+                do {
+                    const char *choiceWord = choiceIterator.GetUTF8Text();
+                    if (choiceWord != NULL) {
+                        NSString *text = [NSString stringWithUTF8String:choiceWord];
+                        CGFloat confidence = choiceIterator.Confidence();
 
-                    G8RecognizedBlock *choiceBlock = [[G8RecognizedBlock alloc] initWithText:text
-                                                                                 boundingBox:block.boundingBox
-                                                                                  confidence:confidence
-                                                                                       level:G8PageIteratorLevelSymbol];
-                    [choices addObject:choiceBlock];
-                }
-            } while (choiceIterator.Next());
+                        G8RecognizedBlock *choiceBlock = [[G8RecognizedBlock alloc] initWithText:text
+                                                                                     boundingBox:block.boundingBox
+                                                                                      confidence:confidence
+                                                                                           level:G8PageIteratorLevelSymbol];
+                        [choices addObject:choiceBlock];
+                    }
+                } while (choiceIterator.Next());
 
-            [array addObject:[choices copy]];
+                [array addObject:[choices copy]];
+            }
         } while (resultIterator->Next(tesseract::RIL_SYMBOL));
         delete resultIterator;
     }

--- a/Tests/RecognitionTests.m
+++ b/Tests/RecognitionTests.m
@@ -229,6 +229,13 @@ describe(@"Blank image", ^{
         helper.customPreprocessingType = G8CustomPreprocessingSimpleThreshold;
     });
 
+    it(@"Should not crash when accessing character choices", ^{
+        [helper recognizeImage];
+        [[theBlock(^{
+            [helper.tesseract characterChoices];
+        }) shouldNot] raise];
+    });
+
     it(@"Should recognize nothing", ^{
         [helper recognizeImage];
 
@@ -358,6 +365,14 @@ describe(@"Hierarchical Data", ^{
         return [helper.tesseract recognizedHierarchicalBlocksByIteratorLevel:level];
     };
 
+    it(@"Should not crash with empty image", ^{
+        [[theBlock(^{
+            helper.image = [XPlatformImage imageWithName:@"image_blank.png"];
+            [helper recognizeImage];
+            [helper.tesseract recognizedHierarchicalBlocksByIteratorLevel:G8PageIteratorLevelBlock];
+        }) shouldNot] raise]; 
+    });
+    
     it(@"Should recognize structure of sample image", ^{
         NSArray *blocks = recognizedHierarchicalBlocksForImageWithName(@"image_sample.jpg", G8PageIteratorLevelBlock);
         [[[blocks should] haveAtLeast:1] items];


### PR DESCRIPTION
Fixed the crash if not text could be recognized and the character choices are requested.